### PR TITLE
fix: correct trace-id header priority and use prependMiddleware

### DIFF
--- a/src/Http/Middleware/TraceIdMiddleware.php
+++ b/src/Http/Middleware/TraceIdMiddleware.php
@@ -18,9 +18,8 @@ class TraceIdMiddleware
      */
     public function handle(Request $request, Closure $next)
     {
-        $traceId = $request->header('X-Amzn-Trace-Id')
-            ?: $request->header('X-Trace-Id')
-            ?: $request->header('X-Request-Id')
+        $traceId = $request->header('X-Request-Id')
+            ?: $request->header('X-Amzn-Trace-Id')
             ?: Uuid::uuid4()->toString();
 
         App::instance('trace-id', $traceId);

--- a/src/LaravelLogEnhancementServiceProvider.php
+++ b/src/LaravelLogEnhancementServiceProvider.php
@@ -52,7 +52,7 @@ class LaravelLogEnhancementServiceProvider extends ServiceProvider
 
         // Ensure the resolved Kernel actually supports pushing middleware (standard for Web Kernels).
         if (method_exists($kernel, 'pushMiddleware')) {
-            $kernel->pushMiddleware(TraceIdMiddleware::class);
+            $kernel->prependMiddleware(TraceIdMiddleware::class);
         }
     }
 

--- a/tests/Unit/Http/Middleware/TraceIdMiddlewareTest.php
+++ b/tests/Unit/Http/Middleware/TraceIdMiddlewareTest.php
@@ -25,7 +25,40 @@ class TraceIdMiddlewareTest extends TestCase
     /**
      * @test
      */
-    public function it_uses_existing_x_amzn_trace_id_header()
+    public function it_uses_x_request_id_as_primary_header()
+    {
+        $request = Request::create('/', 'GET');
+        $request->headers->set('X-Request-Id', 'client-trace-id-123');
+
+        $response = $this->middleware->handle($request, function () {
+            return new Response();
+        });
+
+        $this->assertEquals('client-trace-id-123', App::make('trace-id'));
+        $this->assertEquals('client-trace-id-123', $response->headers->get('X-Request-Id'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_prefers_x_request_id_over_x_amzn_trace_id()
+    {
+        $request = Request::create('/', 'GET');
+        $request->headers->set('X-Request-Id', 'client-trace-id-123');
+        $request->headers->set('X-Amzn-Trace-Id', 'Root=1-67841bd3-169877302925239a05860005');
+
+        $response = $this->middleware->handle($request, function () {
+            return new Response();
+        });
+
+        $this->assertEquals('client-trace-id-123', App::make('trace-id'));
+        $this->assertEquals('client-trace-id-123', $response->headers->get('X-Request-Id'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_falls_back_to_x_amzn_trace_id_when_no_x_request_id()
     {
         $request = Request::create('/', 'GET');
         $request->headers->set('X-Amzn-Trace-Id', 'Root=1-67841bd3-169877302925239a05860005');
@@ -35,38 +68,7 @@ class TraceIdMiddlewareTest extends TestCase
         });
 
         $this->assertEquals('Root=1-67841bd3-169877302925239a05860005', App::make('trace-id'));
-    }
-
-    /**
-     * @test
-     */
-    public function it_uses_existing_x_trace_id_header()
-    {
-        $request = Request::create('/', 'GET');
-        $request->headers->set('X-Trace-Id', 'existing-trace-id-123');
-
-        $response = $this->middleware->handle($request, function () {
-            return new Response();
-        });
-
-        $this->assertEquals('existing-trace-id-123', App::make('trace-id'));
-        $this->assertEquals('existing-trace-id-123', $response->headers->get('X-Request-Id'));
-    }
-
-    /**
-     * @test
-     */
-    public function it_falls_back_to_x_request_id_header()
-    {
-        $request = Request::create('/', 'GET');
-        $request->headers->set('X-Request-Id', 'existing-request-id-456');
-
-        $response = $this->middleware->handle($request, function () {
-            return new Response();
-        });
-
-        $this->assertEquals('existing-request-id-456', App::make('trace-id'));
-        $this->assertEquals('existing-request-id-456', $response->headers->get('X-Request-Id'));
+        $this->assertEquals('Root=1-67841bd3-169877302925239a05860005', $response->headers->get('X-Request-Id'));
     }
 
     /**


### PR DESCRIPTION
## Links
- Trello: https://trello.com/c/5jsvu8tZ/476

## Outcome
- `X-Request-Id` is now the highest priority header (industry standard client header), with `X-Amzn-Trace-Id` as fallback for AWS ALB, then auto-generated UUID
- Removed undocumented `X-Trace-Id` header support (not in spec)
- Changed `pushMiddleware` → `prependMiddleware` so `TraceIdMiddleware` runs before any middleware that may trigger logging
- Updated tests to cover priority precedence (`X-Request-Id` beats `X-Amzn-Trace-Id`)

## Acceptance Criteria Fixes
- Middleware now correctly prioritizes `X-Request-Id` → `X-Amzn-Trace-Id` → UUID (per CT476 spec)

Refs https://trello.com/c/5jsvu8tZ/476