### PR TITLE
fix: use prependMiddleware in method_exists check

### DIFF
--- a/src/LaravelLogEnhancementServiceProvider.php
+++ b/src/LaravelLogEnhancementServiceProvider.php
@@ -50,8 +50,8 @@ class LaravelLogEnhancementServiceProvider extends ServiceProvider
 
         $kernel = $this->app->make(Kernel::class);
 
-        // Ensure the resolved Kernel actually supports pushing middleware (standard for Web Kernels).
-        if (method_exists($kernel, 'pushMiddleware')) {
+        // Ensure the resolved Kernel actually supports prepending middleware (standard for Web Kernels).
+        if (method_exists($kernel, 'prependMiddleware')) {
             $kernel->prependMiddleware(TraceIdMiddleware::class);
         }
     }


### PR DESCRIPTION
## Outcome
- `method_exists($kernel, 'pushMiddleware')` → `method_exists($kernel, 'prependMiddleware')` to match the actual method being called

Fixes inconsistency flagged in PR #23 code review.